### PR TITLE
Changed return value for long running operations

### DIFF
--- a/src/DataReplication/custom/Get-AzDataReplicationProtectedItem.ps1
+++ b/src/DataReplication/custom/Get-AzDataReplicationProtectedItem.ps1
@@ -14,18 +14,25 @@
 function Get-AzDataReplicationProtectedItem {
     [CmdletBinding(DefaultParameterSetName = 'List', PositionalBinding = $false)]
     param (
-        
         [Parameter(ParameterSetName = 'List', Mandatory)]    
+        [Parameter(ParameterSetName = 'GetByProtectedItemName', Mandatory)]
         [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
         [System.String]
         # Specifies the resource group name.
         ${ResourceGroupName},
 
         [Parameter(ParameterSetName = 'List', Mandatory)] 
+        [Parameter(ParameterSetName = 'GetByProtectedItemName', Mandatory)]
         [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
         [System.String]
         # Specifies the vault name
         ${VaultName},
+
+        [Parameter(ParameterSetName = 'GetByProtectedItemName', Mandatory)]
+        [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
+        [System.String]
+        # Specifies the Protected Item name
+        ${ProtectedItemName},
 
         [Parameter(ParameterSetName = 'GetByProtectedItemId', Mandatory)]
         [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
@@ -85,12 +92,13 @@ function Get-AzDataReplicationProtectedItem {
             $ProtectedItemName = $MachineIdArray[10]
         }
         $null = $PSBoundParameters.Remove('ProtectedItemId')
+        $null = $PSBoundParameters.Remove('ProtectedItemName')
         $null = $PSBoundParameters.Remove('ResourceGroupName')
         $null = $PSBoundParameters.Remove('VaultName')
         $null = $PSBoundParameters.Remove('Name')
         $null = $PSBoundParameters.Remove('InputObject')
 
-        if ($null -ne $ProtectedItemName) {
+        if ($parameterSet -ne 'List') {
             $null = $PSBoundParameters.Add("Name", $ProtectedItemName)
         }   
         $null = $PSBoundParameters.Add("ResourceGroupName", $ResourceGroupName)

--- a/src/DataReplication/custom/New-AzDataReplicationProtectedItem.ps1
+++ b/src/DataReplication/custom/New-AzDataReplicationProtectedItem.ps1
@@ -223,10 +223,10 @@ function New-AzDataReplicationProtectedItem {
             $CustomProperty.TestNetworkId = $TestNetworkId
             $CustomProperty.RunAsAccountId = $RunAsAccountId
             $CustomProperty.ApplianceId = $ApplianceId
-            $CustomProperty.DisksToInclude = $DisksToInclude
-            $CustomProperty.TargetCPUCores = $TargetCPUCores
-            $CustomProperty.TargetMemoryInMB = $TargetMemoryInMB
-            $CustomProperty.MultiVMGroupName = $MultiVMGroupName
+            $CustomProperty.DisksToInclude = ($DisksToInclude) ? $DisksToInclude : $null
+            $CustomProperty.TargetCPUCore = ($TargetCPUCores) ? $TargetCPUCores : $null
+            $CustomProperty.TargetMemoryInMegaByte = ($TargetMemoryInMB) ? $TargetMemoryInMB : $null
+            $CustomProperty.MultiVMGroupName = ($MultiVMGroupName) ? $MultiVMGroupName : $null
           
             $null = $PSBoundParameters.Remove('InstanceType')
             $null = $PSBoundParameters.Remove('TargetAvsCloudId')
@@ -263,7 +263,21 @@ function New-AzDataReplicationProtectedItem {
         $null = $PSBoundParameters.Add('VaultName', $VaultName)
         $null = $PSBoundParameters.Add('PolicyName', $PolicyName)
         $null = $PSBoundParameters.Add('ReplicationExtensionName', $ReplicationExtensionName)
+        $null = $PSBoundParameters.Add('NoWait', $true)
         
-        return Az.DataReplication.internal\New-AzDataReplicationProtectedItem @PSBoundParameters
+        $output = Az.DataReplication.internal\New-AzDataReplicationProtectedItem @PSBoundParameters
+        $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+        # Remove parameters which are not necessary for getting job
+        $null = $PSBoundParameters.Remove('Name')
+        $null = $PSBoundParameters.Remove('CustomProperty')
+        $null = $PSBoundParameters.Remove('PolicyName')
+        $null = $PSBoundParameters.Remove('ReplicationExtensionName')
+        $null = $PSBoundParameters.Remove('NoWait')
+
+        # Add the parameters which are required for getting Job
+        $null = $PSBoundParameters.Add('Name', $JobName)
+        $job = Get-AzDataReplicationJob @PSBoundParameters 
+        return $job
     }
 }

--- a/src/DataReplication/custom/Start-AzDataReplicationApplyRecoveryPoint.ps1
+++ b/src/DataReplication/custom/Start-AzDataReplicationApplyRecoveryPoint.ps1
@@ -116,7 +116,20 @@ function Start-AzDataReplicationApplyRecoveryPoint{
        $null = $PSBoundParameters.Add("ProtectedItemName", $ProtectedItemName)
        $null = $PSBoundParameters.Add("RecoveryPointName", $RecoveryPointName)
        $null = $PSBoundParameters.Add("CustomPropertyInstanceType", $CustomPropertyInstanceType)
+       $null = $PSBoundParameters.Add('NoWait', $true)
 
-       return Az.DataReplication.internal\Rename-ProtectedItemRecoveryPoint @PSBoundParameters
+       $output = Az.DataReplication.internal\Rename-ProtectedItemRecoveryPoint @PSBoundParameters
+       $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+       # Remove parameters which are not necessary for getting job
+       $null = $PSBoundParameters.Remove('ProtectedItemName')
+       $null = $PSBoundParameters.Remove('CustomPropertyInstanceType')
+       $null = $PSBoundParameters.Remove('RecoveryPointName')
+       $null = $PSBoundParameters.Remove('NoWait')
+
+       # Add the parameters which are required for getting Job
+       $null = $PSBoundParameters.Add('Name', $JobName)
+       $job = Get-AzDataReplicationJob @PSBoundParameters 
+       return $job
     }
 } 

--- a/src/DataReplication/custom/Start-AzDataReplicationCommitFailoverJob.ps1
+++ b/src/DataReplication/custom/Start-AzDataReplicationCommitFailoverJob.ps1
@@ -75,7 +75,19 @@ function Start-AzDataReplicationCommitFailoverJob {
         $null = $PSBoundParameters.Add('ResourceGroupName', $ResourceGroupName)
         $null = $PSBoundParameters.Add('VaultName', $VaultName)
         $null = $PSBoundParameters.Add('ProtectedItemName', $ProtectedItemName)
+        $null = $PSBoundParameters.Add('NoWait', $true)
 
-        return Az.DataReplication.internal\Invoke-AzDataReplicationCommitProtectedItemFailover @PSBoundParameters
+        $output = Az.DataReplication.internal\Invoke-AzDataReplicationCommitProtectedItemFailover @PSBoundParameters
+        $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+        # Remove parameters which are not necessary for getting job
+        $null = $PSBoundParameters.Remove('ProtectedItemName')
+        $null = $PSBoundParameters.Remove('CustomProperty')
+        $null = $PSBoundParameters.Remove('NoWait')
+
+        # Add the parameters which are required for getting Job
+        $null = $PSBoundParameters.Add('Name', $JobName)
+        $job = Get-AzDataReplicationJob @PSBoundParameters 
+        return $job
     }
 }   

--- a/src/DataReplication/custom/Start-AzDataReplicationPlannedFailoverJob.ps1
+++ b/src/DataReplication/custom/Start-AzDataReplicationPlannedFailoverJob.ps1
@@ -115,7 +115,19 @@ function Start-AzDataReplicationPlannedFailoverJob {
         $null = $PSBoundParameters.Add('VaultName', $VaultName)
         $null = $PSBoundParameters.Add('ProtectedItemName', $ProtectedItemName)
         $null = $PSBoundParameters.Add('CustomProperty', $CustomProperty)
-        
-        return Az.DataReplication.internal\Invoke-AzDataReplicationPlannedProtectedItemFailover @PSBoundParameters
+        $null = $PSBoundParameters.Add('NoWait', $true)
+
+        $output = Az.DataReplication.internal\Invoke-AzDataReplicationPlannedProtectedItemFailover @PSBoundParameters
+        $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+        # Remove parameters which are not necessary for getting job
+        $null = $PSBoundParameters.Remove('ProtectedItemName')
+        $null = $PSBoundParameters.Remove('CustomProperty')
+        $null = $PSBoundParameters.Remove('NoWait')
+
+        # Add the parameters which are required for getting Job
+        $null = $PSBoundParameters.Add('Name', $JobName)
+        $job = Get-AzDataReplicationJob @PSBoundParameters 
+        return $job
     }
 }   

--- a/src/DataReplication/custom/Start-AzDataReplicationReprotectionJob.ps1
+++ b/src/DataReplication/custom/Start-AzDataReplicationReprotectionJob.ps1
@@ -154,7 +154,19 @@ function Start-AzDataReplicationReprotectionJob {
         $null = $PSBoundParameters.Add('VaultName', $VaultName)
         $null = $PSBoundParameters.Add('ProtectedItemName', $ProtectedItemName)
         $null = $PSBoundParameters.Add('CustomProperty', $CustomProperty)
+        $null = $PSBoundParameters.Add('NoWait', $true)
 
-        return Az.DataReplication.internal\Invoke-AzDataReplicationReprotectProtectedItem @PSBoundParameters
+        $output = Az.DataReplication.internal\Invoke-AzDataReplicationReprotectProtectedItem @PSBoundParameters
+        $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+        # Remove parameters which are not necessary for getting job
+        $null = $PSBoundParameters.Remove('ProtectedItemName')
+        $null = $PSBoundParameters.Remove('CustomProperty')
+        $null = $PSBoundParameters.Remove('NoWait')
+
+        # Add the parameters which are required for getting Job
+        $null = $PSBoundParameters.Add('Name', $JobName)
+        $job = Get-AzDataReplicationJob @PSBoundParameters 
+        return $job
     }
 }   

--- a/src/DataReplication/custom/Start-AzDataReplicationResynchronizeJob.ps1
+++ b/src/DataReplication/custom/Start-AzDataReplicationResynchronizeJob.ps1
@@ -74,7 +74,18 @@ function Start-AzDataReplicationResynchronizeJob {
         $null = $PSBoundParameters.Add("ResourceGroupName", $ResourceGroupName)
         $null = $PSBoundParameters.Add("VaultName", $VaultName)
         $null = $PSBoundParameters.Add("ProtectedItemName", $ProtectedItemName)
+        $null = $PSBoundParameters.Add('NoWait', $true)
 
-        return Az.DataReplication.internal\Invoke-AzDataReplicationResynchronizeProtectedItem @PSBoundParameters
+        $output = Az.DataReplication.internal\Invoke-AzDataReplicationResynchronizeProtectedItem @PSBoundParameters
+        $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+        # Remove parameters which are not necessary for getting job
+        $null = $PSBoundParameters.Remove('ProtectedItemName')
+        $null = $PSBoundParameters.Remove('NoWait')
+
+        # Add the parameters which are required for getting Job
+        $null = $PSBoundParameters.Add('Name', $JobName)
+        $job = Get-AzDataReplicationJob @PSBoundParameters | Format-List
+        return $job  
     }
 }    

--- a/src/DataReplication/custom/Start-AzDataReplicationTestFailoverCleanupJob.ps1
+++ b/src/DataReplication/custom/Start-AzDataReplicationTestFailoverCleanupJob.ps1
@@ -82,7 +82,18 @@ function Start-AzDataReplicationTestFailoverCleanupJob {
         $null = $PSBoundParameters.Add('ResourceGroupName', $ResourceGroupName)
         $null = $PSBoundParameters.Add('VaultName', $VaultName)
         $null = $PSBoundParameters.Add('ProtectedItemName', $ProtectedItemName)
+        $null = $PSBoundParameters.Add('NoWait', $true)
 
-        return Az.DataReplication.internal\Test-AzDataReplicationProtectedItemFailoverCleanup @PSBoundParameters
+        $output = Az.DataReplication.internal\Test-AzDataReplicationProtectedItemFailoverCleanup @PSBoundParameters
+        $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+        # Remove parameters which are not necessary for getting job
+        $null = $PSBoundParameters.Remove('ProtectedItemName')
+        $null = $PSBoundParameters.Remove('NoWait')
+
+        # Add the parameters which are required for getting Job
+        $null = $PSBoundParameters.Add('Name', $JobName)
+        $job = Get-AzDataReplicationJob @PSBoundParameters | Format-List
+        return $job
     }
 }   

--- a/src/DataReplication/custom/Start-AzDataReplicationTestFailoverJob.ps1
+++ b/src/DataReplication/custom/Start-AzDataReplicationTestFailoverJob.ps1
@@ -124,7 +124,19 @@ function Start-AzDataReplicationTestFailoverJob {
         $null = $PSBoundParameters.Add('VaultName', $VaultName)
         $null = $PSBoundParameters.Add('ProtectedItemName', $ProtectedItemName)
         $null = $PSBoundParameters.Add('CustomProperty', $CustomProperty)
+        $null = $PSBoundParameters.Add('NoWait', $true)
 
-        return Az.DataReplication.internal\Test-AzDataReplicationProtectedItemFailover @PSBoundParameters   
+        $output = Az.DataReplication.internal\Test-AzDataReplicationProtectedItemFailover @PSBoundParameters 
+        $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+        # Remove parameters which are not necessary for getting job
+        $null = $PSBoundParameters.Remove('ProtectedItemName')
+        $null = $PSBoundParameters.Remove('CustomProperty')
+        $null = $PSBoundParameters.Remove('NoWait')
+
+        # Add the parameters which are required for getting Job
+        $null = $PSBoundParameters.Add('Name', $JobName)
+        $job = Get-AzDataReplicationJob @PSBoundParameters 
+        return $job  
     }
 }   

--- a/src/DataReplication/custom/Start-AzDataReplicationUnplannedFailoverJob.ps1
+++ b/src/DataReplication/custom/Start-AzDataReplicationUnplannedFailoverJob.ps1
@@ -123,7 +123,19 @@ function Start-AzDataReplicationUnplannedFailoverJob {
         $null = $PSBoundParameters.Add('VaultName', $VaultName)
         $null = $PSBoundParameters.Add('ProtectedItemName', $ProtectedItemName)
         $null = $PSBoundParameters.Add('CustomProperty', $CustomProperty)
-        
-        return Az.DataReplication.internal\Invoke-AzDataReplicationUnplannedProtectedItemFailover @PSBoundParameters
+        $null = $PSBoundParameters.Add('NoWait', $true)
+
+        $output = Az.DataReplication.internal\Invoke-AzDataReplicationUnplannedProtectedItemFailover @PSBoundParameters
+        $JobName = $output.Target.Split("/")[14].Split("?")[0]
+
+        # Remove parameters which are not necessary for getting job
+        $null = $PSBoundParameters.Remove('ProtectedItemName')
+        $null = $PSBoundParameters.Remove('CustomProperty')
+        $null = $PSBoundParameters.Remove('NoWait')
+
+        # Add the parameters which are required for getting Job
+        $null = $PSBoundParameters.Add('Name', $JobName)
+        $job = Get-AzDataReplicationJob @PSBoundParameters 
+        return $job 
     }
 }  

--- a/src/DataReplication/custom/Update-AzDataReplicationProtectedItem.ps1
+++ b/src/DataReplication/custom/Update-AzDataReplicationProtectedItem.ps1
@@ -247,7 +247,7 @@ function Update-AzDataReplicationProtectedItem {
         # Get the existing properties of the protected item
         $ProtectedItem =  Az.DataReplication.internal\Get-AzDataReplicationProtectedItem @PSBoundParameters
         
-        # Check if protected item exists and crrect provider is given 
+        # Check if protected item exists and correct provider is given 
         if ($ProtectedItem -and $acceptedInstanceTypes.Contains($ProtectedItem.CustomProperty.InstanceType)) {
             $CustomProperty = [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Models.Api20210216Preview.VMwareToAvsProtectedItemModelCustomProperties]::new()
             $CustomProperty.InstanceType = $ProtectedItem.CustomProperty.InstanceType
@@ -277,8 +277,22 @@ function Update-AzDataReplicationProtectedItem {
             $null = $PSBoundParameters.Add('CustomProperty', $CustomProperty)
             $null = $PSBoundParameters.Add('PolicyName', $PolicyName)
             $null = $PSBoundParameters.Add('ReplicationExtensionName', $ReplicationExtensionName)
-
-            return Az.DataReplication.internal\Update-AzDataReplicationProtectedItem @PSBoundParameters
+            $null = $PSBoundParameters.Add('NoWait', $true)
+        
+            $output = Az.DataReplication.internal\Update-AzDataReplicationProtectedItem @PSBoundParameters
+            $JobName = $output.Target.Split("/")[14].Split("?")[0]
+    
+            # Remove parameters which are not necessary for getting job
+            $null = $PSBoundParameters.Remove('Name')
+            $null = $PSBoundParameters.Remove('CustomProperty')
+            $null = $PSBoundParameters.Remove('PolicyName')
+            $null = $PSBoundParameters.Remove('ReplicationExtensionName')
+            $null = $PSBoundParameters.Remove('NoWait')
+    
+            # Add the parameters which are required for getting Job
+            $null = $PSBoundParameters.Add('Name', $JobName)
+            $job = Get-AzDataReplicationJob @PSBoundParameters 
+            return $job
         }
        else{
         throw "Either the protected item does not exist or the provider is not supported"

--- a/src/DataReplication/docs/Get-AzDataReplicationProtectedItem.md
+++ b/src/DataReplication/docs/Get-AzDataReplicationProtectedItem.md
@@ -30,6 +30,12 @@ Get-AzDataReplicationProtectedItem -ProtectedItemId <String> [-SubscriptionId <S
  [-DefaultProfile <PSObject>] [-AsJob] [-NoWait] [-PassThru] [<CommonParameters>]
 ```
 
+### GetByProtectedItemName
+```
+Get-AzDataReplicationProtectedItem -ProtectedItemName <String> -ResourceGroupName <String> -VaultName <String>
+ [-SubscriptionId <String[]>] [-DefaultProfile <PSObject>] [-AsJob] [-NoWait] [-PassThru] [<CommonParameters>]
+```
+
 ## DESCRIPTION
 
 
@@ -149,12 +155,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProtectedItemName
+
+
+```yaml
+Type: System.String
+Parameter Sets: GetByProtectedItemName
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ResourceGroupName
 
 
 ```yaml
 Type: System.String
-Parameter Sets: List
+Parameter Sets: GetByProtectedItemName, List
 Aliases:
 
 Required: True
@@ -184,7 +205,7 @@ Accept wildcard characters: False
 
 ```yaml
 Type: System.String
-Parameter Sets: List
+Parameter Sets: GetByProtectedItemName, List
 Aliases:
 
 Required: True

--- a/src/DataReplication/exports/Get-AzDataReplicationProtectedItem.ps1
+++ b/src/DataReplication/exports/Get-AzDataReplicationProtectedItem.ps1
@@ -51,11 +51,13 @@ function Get-AzDataReplicationProtectedItem {
 [CmdletBinding(DefaultParameterSetName='List', PositionalBinding=$false)]
 param(
     [Parameter(ParameterSetName='List', Mandatory)]
+    [Parameter(ParameterSetName='GetByProtectedItemName', Mandatory)]
     [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
     [System.String]
     ${ResourceGroupName},
 
     [Parameter(ParameterSetName='List', Mandatory)]
+    [Parameter(ParameterSetName='GetByProtectedItemName', Mandatory)]
     [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
     [System.String]
     ${VaultName},
@@ -65,6 +67,11 @@ param(
     [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Runtime.DefaultInfo(Script='(Get-AzContext).Subscription.Id')]
     [System.String[]]
     ${SubscriptionId},
+
+    [Parameter(ParameterSetName='GetByProtectedItemName', Mandatory)]
+    [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
+    [System.String]
+    ${ProtectedItemName},
 
     [Parameter(ParameterSetName='GetByProtectedItemId', Mandatory)]
     [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
@@ -127,10 +134,11 @@ begin {
 
         $mapping = @{
             List = 'Az.DataReplication.custom\Get-AzDataReplicationProtectedItem';
+            GetByProtectedItemName = 'Az.DataReplication.custom\Get-AzDataReplicationProtectedItem';
             GetByProtectedItemId = 'Az.DataReplication.custom\Get-AzDataReplicationProtectedItem';
             GetByInputObject = 'Az.DataReplication.custom\Get-AzDataReplicationProtectedItem';
         }
-        if (('List', 'GetByProtectedItemId', 'GetByInputObject') -contains $parameterSet -and -not $PSBoundParameters.ContainsKey('SubscriptionId')) {
+        if (('List', 'GetByProtectedItemName', 'GetByProtectedItemId', 'GetByInputObject') -contains $parameterSet -and -not $PSBoundParameters.ContainsKey('SubscriptionId')) {
             $PSBoundParameters['SubscriptionId'] = (Get-AzContext).Subscription.Id
         }
         $cmdInfo = Get-Command -Name $mapping[$parameterSet]

--- a/src/DataReplication/exports/ProxyCmdletDefinitions.ps1
+++ b/src/DataReplication/exports/ProxyCmdletDefinitions.ps1
@@ -3866,11 +3866,13 @@ function Get-AzDataReplicationProtectedItem {
 [CmdletBinding(DefaultParameterSetName='List', PositionalBinding=$false)]
 param(
     [Parameter(ParameterSetName='List', Mandatory)]
+    [Parameter(ParameterSetName='GetByProtectedItemName', Mandatory)]
     [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
     [System.String]
     ${ResourceGroupName},
 
     [Parameter(ParameterSetName='List', Mandatory)]
+    [Parameter(ParameterSetName='GetByProtectedItemName', Mandatory)]
     [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
     [System.String]
     ${VaultName},
@@ -3880,6 +3882,11 @@ param(
     [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Runtime.DefaultInfo(Script='(Get-AzContext).Subscription.Id')]
     [System.String[]]
     ${SubscriptionId},
+
+    [Parameter(ParameterSetName='GetByProtectedItemName', Mandatory)]
+    [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
+    [System.String]
+    ${ProtectedItemName},
 
     [Parameter(ParameterSetName='GetByProtectedItemId', Mandatory)]
     [Microsoft.Azure.PowerShell.Cmdlets.DataReplication.Category('Path')]
@@ -3942,10 +3949,11 @@ begin {
 
         $mapping = @{
             List = 'Az.DataReplication.custom\Get-AzDataReplicationProtectedItem';
+            GetByProtectedItemName = 'Az.DataReplication.custom\Get-AzDataReplicationProtectedItem';
             GetByProtectedItemId = 'Az.DataReplication.custom\Get-AzDataReplicationProtectedItem';
             GetByInputObject = 'Az.DataReplication.custom\Get-AzDataReplicationProtectedItem';
         }
-        if (('List', 'GetByProtectedItemId', 'GetByInputObject') -contains $parameterSet -and -not $PSBoundParameters.ContainsKey('SubscriptionId')) {
+        if (('List', 'GetByProtectedItemName', 'GetByProtectedItemId', 'GetByInputObject') -contains $parameterSet -and -not $PSBoundParameters.ContainsKey('SubscriptionId')) {
             $PSBoundParameters['SubscriptionId'] = (Get-AzContext).Subscription.Id
         }
         $cmdInfo = Get-Command -Name $mapping[$parameterSet]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

1. Return job for all long running operations.
   - Previously long running operations used to keep polling the server for information and the user would not be able to do anything. Now using -NoWait operation id is returned and then the job is fetched.

## Checklist

- [x] I have read the [_Submitting Changes_](../blob/master/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md)
- [x] The title of the PR is clear and informative
- [ ] The appropriate `ChangeLog.md` file(s) has been updated:
    - For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    - A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header -- no new version header should be added
- [ ] The PR does not introduce [breaking changes](../blob/master/documentation/breaking-changes/breaking-changes-definition.md)
- [ ] If applicable, the changes made in the PR have proper test coverage
- [ ] For public API changes to cmdlets:
    - [ ] a cmdlet design review was approved for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) (_Microsoft internal only_)
        - {Please put the link here}
    - [ ] the markdown help files have been regenerated using the commands listed [here](../blob/master/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
