### PR TITLE
Add Trusted Launch security type support to New-AzMigrateServerReplication

### DIFF
--- a/src/Migrate/Migrate.Autorest/custom/New-AzMigrateServerReplication.ps1
+++ b/src/Migrate/Migrate.Autorest/custom/New-AzMigrateServerReplication.ps1
@@ -193,6 +193,20 @@ function New-AzMigrateServerReplication {
         # Specifies the Operating System disk for the source server to be migrated.
         ${OSDiskID},
 
+        [ValidateSet("Standard" , "TrustedLaunch")]
+        [ArgumentCompleter( { "Standard" , "TrustedLaunch" })]
+        [Microsoft.Azure.PowerShell.Cmdlets.Migrate.Category('Path')]
+        [System.String]
+        # Specifies the security type for the Azure VM.
+        ${TargetSecurityType},
+
+        [ValidateSet("true" , "false")]
+        [ArgumentCompleter( { "true" , "false" })]
+        [Microsoft.Azure.PowerShell.Cmdlets.Migrate.Category('Path')]
+        [System.String]
+        # Specifies if secure boot needs to be enabled on target VM.
+        ${TargetVMSecureBootEnabled},
+
         [Parameter(ParameterSetName = 'ByIdDefaultUser')]
         [Parameter(ParameterSetName = 'ByInputObjectDefaultUser')]
         [Microsoft.Azure.PowerShell.Cmdlets.Migrate.Category('Path')]
@@ -270,6 +284,8 @@ function New-AzMigrateServerReplication {
         $HasResync = $PSBoundParameters.ContainsKey('PerformAutoResync')
         $HasDiskEncryptionSetID = $PSBoundParameters.ContainsKey('DiskEncryptionSetID')
         $HasTargetVMSize = $PSBoundParameters.ContainsKey('TargetVMSize')
+        $HasTargetSecurityType = $PSBoundParameters.ContainsKey('TargetSecurityType')
+        $HasTargetVMSecureBootEnabled = $PSBoundParameters.ContainsKey('TargetVMSecureBootEnabled')
 
         $null = $PSBoundParameters.Remove('ReplicationContainerMapping')
         $null = $PSBoundParameters.Remove('VMWarerunasaccountID')
@@ -296,6 +312,8 @@ function New-AzMigrateServerReplication {
         $null = $PSBoundParameters.Remove('LinuxLicenseType')
         $null = $PSBoundParameters.Remove('LicenseType')
         $null = $PSBoundParameters.Remove('DiskEncryptionSetID')
+        $null = $PSBoundParameters.Remove('TargetSecurityType')
+        $null = $PSBoundParameters.Remove('TargetVMSecureBootEnabled')
 
         $null = $PSBoundParameters.Remove('MachineId')
         $null = $PSBoundParameters.Remove('InputObject')
@@ -549,6 +567,19 @@ public static int hashForArtifact(String artifact)
         $ProviderSpecificDetails.InstanceType = 'VMwareCbt'
         $ProviderSpecificDetails.LicenseType = $LicenseType
         $ProviderSpecificDetails.PerformAutoResync = $PerformAutoResync
+        if ($HasTargetVMSecureBootEnabled) {
+            $ProviderSpecificDetails.TargetVMSecurityProfileIsTargetVmsecureBootEnabled = $TargetVMSecureBootEnabled
+        } elseif ($TargetSecurityType -eq "TrustedLaunch") {
+            $ProviderSpecificDetails.TargetVMSecurityProfileIsTargetVmsecureBootEnabled = "true"
+        }
+
+        if ($HasTargetSecurityType -and $TargetSecurityType -ne "Standard") {
+            $ProviderSpecificDetails.TargetVMSecurityProfileTargetVmsecurityType = $TargetSecurityType
+            $ProviderSpecificDetails.TargetVMSecurityProfileIsTargetVmtpmEnabled = $true
+        } elseif ($HasTargetVMSecureBootEnabled) {
+            throw "SecureBoot is supported only when security type is trusted launch virtual machine."
+        }
+
         if ($HasTargetAVSet) {
             $ProviderSpecificDetails.TargetAvailabilitySetId = $TargetAvailabilitySet
         }
@@ -744,7 +775,5 @@ public static int hashForArtifact(String artifact)
         $null = $PSBoundParameters.Add('ResourceGroupName', $ResourceGroupName)
         
         return Az.Migrate.internal\Get-AzMigrateReplicationJob @PSBoundParameters
-        
     }
-
-}   
+}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

This PR adds support for Trusted Launch security type for Azure Migrate server replication. 

**Changes made:**
- Added `TargetSecurityType` parameter to specify security type for Azure VM (Standard or TrustedLaunch)
- Added `TargetVMSecureBootEnabled` parameter to control secure boot on target VM
- Implemented security profile configuration logic that automatically enables TPM when TrustedLaunch is selected
- Added validation to ensure SecureBoot is only used with TrustedLaunch security type
- Removed unnecessary `Az.Compute` module import that was redundant
- Removed disk encryption set configuration from data disks in DefaultUser mode

**Design decisions:**
- When `TargetSecurityType` is set to "TrustedLaunch" without explicitly setting `TargetVMSecureBootEnabled`, secure boot is automatically enabled (defaults to "true")
- TPM is automatically enabled when security type is TrustedLaunch
- SecureBoot parameter throws an error if used without TrustedLaunch security type

This implementation is based on the changes from AsrOneSdk/azure-powershell PR #37 which was never merged.

**ChangeLog:**
```
* Added support for Trusted Launch security type in New-AzMigrateServerReplication
  - Added TargetSecurityType parameter to specify VM security type (Standard or TrustedLaunch)
  - Added TargetVMSecureBootEnabled parameter to control secure boot setting
```

## Checklist

- [ ] Check this box to confirm: **I have read the [_Submitting Changes_](../blob/main/CONTRIBUTING.md#submitting-changes) section of [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) and reviewed the following information:**

* **SHOULD** select appropriate branch. Cmdlets from Autorest.PowerShell should go to [`generation`](https://github.com/Azure/azure-powershell/tree/generation) branch. 
* **SHOULD** make the title of PR clear and informative, and in the present imperative tense. 
* **SHOULD** update `ChangeLog.md` file(s) appropriately
    * For any service, the `ChangeLog.md` file can be found at `src/{{SERVICE}}/{{SERVICE}}/ChangeLog.md`
    * A snippet outlining the change(s) made in the PR should be written under the `## Upcoming Release` header in the past tense. Add changelog in description section if PR goes into [`generation`](https://github.com/Azure/azure-powershell/tree/generation) branch.
    * Should **not** change `ChangeLog.md` if no new release is required, such as fixing test case only.
* **SHOULD** have approved design review for the changes in [this repository](https://github.com/Azure/azure-powershell-cmdlet-review-pr) ([_Microsoft internal only_](../blob/main/CONTRIBUTING.md#onboarding)) with following situations
    * Create new module from scratch
    * Create new resource types which are not easy to conform to [Azure PowerShell Design Guidelines](../blob/main/documentation/development-docs/design-guidelines)
    * Create new resource type which name doesn't use module name as prefix
    * Have design question before implementation
* **SHOULD** regenerate markdown help files if there is cmdlet API change. [Instruction](../blob/main/documentation/development-docs/help-generation.md#updating-all-markdown-files-in-a-module)
* **SHOULD** have proper test coverage for changes in pull request.
* **SHOULD NOT** introduce [breaking changes](../blob/main/documentation/breaking-changes/breaking-changes-definition.md) in Az minor release except preview version.
* **SHOULD NOT** adjust version of module manually in pull request
